### PR TITLE
fix: Kotlin class 초기화 순서에 따른 오류 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     defaultConfig {
         applicationId = "com.jinproject.twomillustratedbook"
         targetSdk = 36
-        versionCode = 95
+        versionCode = 96
         versionName = "2.5.4"
     }
 

--- a/features/core/src/main/kotlin/com/jinproject/features/core/BillingModule.kt
+++ b/features/core/src/main/kotlin/com/jinproject/features/core/BillingModule.kt
@@ -39,6 +39,10 @@ class BillingModule(
 ) {
     var isReady: Boolean = false
 
+    private val successListener: BillingListener<Purchase> = BillingListener()
+    private val failListener: BillingListener<Int> = BillingListener()
+    private val readyListener: BillingListener<BillingModule> = BillingListener()
+
     private val purChasedUpdatedListener = PurchasesUpdatedListener { billingResult, purchases ->
         when (billingResult.responseCode) {
             BillingClient.BillingResponseCode.OK -> {
@@ -91,10 +95,6 @@ class BillingModule(
             }
         })
     }
-
-    private val successListener: BillingListener<Purchase> = BillingListener()
-    private val failListener: BillingListener<Int> = BillingListener()
-    private val readyListener: BillingListener<BillingModule> = BillingListener()
 
     /**
      * 결제 플로우 리스너 등록

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-activity = "1.12.0-alpha01"
+activity = "1.13.0-alpha01"
 android-test-ext = "1.1.5"
 appCompat = "1.7.1"
 billing = "8.3.0"
@@ -31,7 +31,7 @@ lifecycleViewmodelNav3 = "2.10.0"
 lottie = "6.3.0"
 material = "1.11.0"
 mockk = "1.13.5"
-navigation = "1.0.1"
+navigation = "1.1.0-alpha04"
 okhttp3 = "4.12.0"
 playInApp = "2.1.0"
 protobuf = "3.25.0"


### PR DESCRIPTION
- Kotlin Class 는 생성자 프로퍼티 초기화 이후 블록 내부의 프로퍼티와 init{} 블록을 선언 순서대로 초기화 함
- init {} 내부에서 initBillingClient() 가 호출되는데, test 환경에서와 같이 BillingClient.startConnection() 이 동기적으로 바로 실행되는 경우 readyListener#call 또는 failListener#call 이 초기화 되기 전에 실행될 수 있음
- 따라서, listener 프로퍼티 선언을 그보다 위에 선언해야함.
